### PR TITLE
'save_to' and 'open_in_browser' config options added

### DIFF
--- a/upscrot/main.py
+++ b/upscrot/main.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 import webbrowser
 import sys
+import time
 
 import appdirs
 
@@ -78,6 +79,7 @@ def main(config):
 
     # Take screenshot
     try:
+        time.sleep(0.2)
         subprocess.check_call(['scrot', '-s', filename], stdout=subprocess.DEVNULL)
     except subprocess.CalledProcessError as e:
         print('Could not take screenshot: %s' % e)

--- a/upscrot/main.py
+++ b/upscrot/main.py
@@ -115,10 +115,11 @@ def main(config):
         if config.get('upload', 'open_in_browser', fallback=False):
             webbrowser.open(url, autoraise=False)
 
-    try:
-        print(url, flush=True)
-    except (BrokenPipeError, IOError):
-        pass
+        try:
+            print(url, flush=True)
+        except (BrokenPipeError, IOError):
+            pass
+
     sys.stderr.close()
 
 


### PR DESCRIPTION
Hi!
I made some improvements in your script:
1. new `save_to` config option allows to save screenshots to local directory before uploading
2. new `open_in_browser` config option sets if screenshot url must be opened in browser immediatelly after upload
3. replaced all `config['section'].get('option', 'default')` to `config.get('section', 'option', fallback='default')`. This will protect the script from exceptions, if user deletes any sections from config, plus - script can be used without uploading too.
4. fixes pipe-ing, like: `upscrot | tee`
5. added a small sleep before `scrot` call to allow using the script with keybindings. Without this sleep there is no enough time to release a key and scrot fails.
